### PR TITLE
urn.desktop: use relative path in Exec

### DIFF
--- a/urn.desktop
+++ b/urn.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Urn
-Exec=/usr/local/bin/urn-gtk
+Exec=urn-gtk
 Icon=urn
 Type=Application
 Categories=GTK;GNOME;Utility;


### PR DESCRIPTION
PREFIX is not always /usr/local

/usr/local is for manually installed programs. Most distros set PREFIX to /usr/bin in their packages, and NixOS sets it to /nix/store/[some hash]. The installed binary is supposed to be in $PATH, so a relative Exec path works best