### PR TITLE
Remove forcing of X11 backend in .desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 	install -Dm644 $(APP) $(APP_DIR)/$(APP)
 	for size in 16 22 24 32 36 48 64 72 96 128 256 512; do \
 	  mkdir -p $(ICON_DIR)/"$$size"x"$$size"/apps ; \
-	  convert static/$(ICON) -resize "$$size"x"$$size" \
+	  magick static/$(ICON) -resize "$$size"x"$$size" \
 	          $(ICON_DIR)/"$$size"x"$$size"/apps/$(ICON) ; \
 	done
 	gtk-update-icon-cache -f -t $(ICON_DIR)

--- a/urn.desktop
+++ b/urn.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Urn
-Exec=env GDK_BACKEND=x11 urn-gtk
+Exec=urn-gtk
 Icon=urn
 Type=Application
 Categories=GTK;GNOME;Utility;


### PR DESCRIPTION
Urn is forced run in X11/XWayland by its .desktop file eventhough it works just fine when running nativly on Wayland.