### PR TITLE
remove unsupported color meanings from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The color of a time or delta has a special meaning.
 | Dark red    | Behind splits in PB and losing time    |
 | Light red   | Behind splits in PB and gaining time   |
 | Dark green  | Ahead of splits in PB and gaining time |
+| Blue        | Best split time in any run             |
 | Gold        | Best segment time in any run           |
 
 ## Split Files

--- a/README.md
+++ b/README.md
@@ -166,8 +166,6 @@ The color of a time or delta has a special meaning.
 | Dark red    | Behind splits in PB and losing time    |
 | Light red   | Behind splits in PB and gaining time   |
 | Dark green  | Ahead of splits in PB and gaining time |
-| Light green | Ahead of splits in PB and losing time  |
-| Blue        | Best split time in any run             |
 | Gold        | Best segment time in any run           |
 
 ## Split Files


### PR DESCRIPTION
light green meaning isnt themable at the moment, and not implement from what i can see, not even the default theme has it, therefor it should be removed.

i'd be awsome to have light green able to be used, since currently it simply uses dark red if you are loosing time, even if you're still in total time gain.